### PR TITLE
Add remote name

### DIFF
--- a/gitstatus.plugin.zsh
+++ b/gitstatus.plugin.zsh
@@ -27,6 +27,7 @@
 #   VCS_STATUS_COMMIT          Commit hash that HEAD is pointing to. Either 40 hex digits or empty
 #                              if there is no HEAD (empty repo).
 #   VCS_STATUS_LOCAL_BRANCH    Local branch name or empty if not on a branch.
+#   VCS_STATUS_REMOTE_NAME     The remote name, e.g. "upstream" or "origin".
 #   VCS_STATUS_REMOTE_BRANCH   Upstream branch name. Can be empty.
 #   VCS_STATUS_REMOTE_URL      Remote URL. Can be empty.
 #   VCS_STATUS_ACTION          Repository state, A.K.A. action. Can be empty.
@@ -121,15 +122,16 @@ function _gitstatus_process_response() {
     typeset -g  VCS_STATUS_COMMIT="${VCS_STATUS_ALL[2]}"
     typeset -g  VCS_STATUS_LOCAL_BRANCH="${VCS_STATUS_ALL[3]}"
     typeset -g  VCS_STATUS_REMOTE_BRANCH="${VCS_STATUS_ALL[4]}"
-    typeset -g  VCS_STATUS_REMOTE_URL="${VCS_STATUS_ALL[5]}"
-    typeset -g  VCS_STATUS_ACTION="${VCS_STATUS_ALL[6]}"
-    typeset -gi VCS_STATUS_HAS_STAGED="${VCS_STATUS_ALL[7]}"
-    typeset -gi VCS_STATUS_HAS_UNSTAGED="${VCS_STATUS_ALL[8]}"
-    typeset -gi VCS_STATUS_HAS_UNTRACKED="${VCS_STATUS_ALL[9]}"
-    typeset -gi VCS_STATUS_COMMITS_AHEAD="${VCS_STATUS_ALL[10]}"
-    typeset -gi VCS_STATUS_COMMITS_BEHIND="${VCS_STATUS_ALL[11]}"
-    typeset -gi VCS_STATUS_STASHES="${VCS_STATUS_ALL[12]}"
-    typeset -g  VCS_STATUS_TAG="${VCS_STATUS_ALL[13]}"
+    typeset -g  VCS_STATUS_REMOTE_NAME="${VCS_STATUS_ALL[5]}"
+    typeset -g  VCS_STATUS_REMOTE_URL="${VCS_STATUS_ALL[6]}"
+    typeset -g  VCS_STATUS_ACTION="${VCS_STATUS_ALL[7]}"
+    typeset -gi VCS_STATUS_HAS_STAGED="${VCS_STATUS_ALL[8]}"
+    typeset -gi VCS_STATUS_HAS_UNSTAGED="${VCS_STATUS_ALL[9]}"
+    typeset -gi VCS_STATUS_HAS_UNTRACKED="${VCS_STATUS_ALL[10]}"
+    typeset -gi VCS_STATUS_COMMITS_AHEAD="${VCS_STATUS_ALL[11]}"
+    typeset -gi VCS_STATUS_COMMITS_BEHIND="${VCS_STATUS_ALL[12]}"
+    typeset -gi VCS_STATUS_STASHES="${VCS_STATUS_ALL[13]}"
+    typeset -g  VCS_STATUS_TAG="${VCS_STATUS_ALL[14]}"
   } || {
     (( ours )) && VCS_STATUS_RESULT=norepo-sync || VCS_STATUS_RESULT=norepo-async
     unset VCS_STATUS_ALL
@@ -137,6 +139,7 @@ function _gitstatus_process_response() {
     unset VCS_STATUS_COMMIT
     unset VCS_STATUS_LOCAL_BRANCH
     unset VCS_STATUS_REMOTE_BRANCH
+    unset VCS_STATUS_REMOTE_NAME
     unset VCS_STATUS_REMOTE_URL
     unset VCS_STATUS_ACTION
     unset VCS_STATUS_HAS_STAGED

--- a/src/git.cc
+++ b/src/git.cc
@@ -183,15 +183,15 @@ const char* LocalBranchName(const git_reference* ref) {
   throw Exception();
 }
 
-const char* RemoteBranchName(git_repository* repo, const git_reference* ref) {
+Remote GetRemote(git_repository* repo, const git_reference* ref) {
   const char* branch = nullptr;
-  if (git_branch_name(&branch, ref)) return "";
+  if (!ref || git_branch_name(&branch, ref)) return {};
   git_buf remote = {};
-  if (git_branch_remote_name(&remote, repo, git_reference_name(ref))) return "";
+  if (git_branch_remote_name(&remote, repo, git_reference_name(ref))) return {};
   ON_SCOPE_EXIT(&) { git_buf_free(&remote); };
   VERIFY(std::strstr(branch, remote.ptr) == branch);
   VERIFY(branch[remote.size] == '/');
-  return branch + remote.size + 1;
+  return {remote.ptr, branch + remote.size + 1};
 }
 
 }  // namespace gitstatus

--- a/src/git.h
+++ b/src/git.h
@@ -53,8 +53,17 @@ git_reference* Upstream(git_reference* local);
 // Returns the name of the local branch, or an empty string.
 const char* LocalBranchName(const git_reference* ref);
 
-// Returns the name of the remote tracking branch, or an empty string.
-const char* RemoteBranchName(git_repository* repo, const git_reference* ref);
+struct Remote {
+  // Name of the tracking remote. For example, "origin".
+  // Empty if there is no tracking remote.
+  std::string name;
+
+  // Name of the tracking remote branch. For example, "master".
+  // Empty if there is no tracking remote.
+  std::string branch;
+};
+
+Remote GetRemote(git_repository* repo, const git_reference* ref);
 
 }  // namespace gitstatus
 

--- a/src/gitstatus.cc
+++ b/src/gitstatus.cc
@@ -78,8 +78,15 @@ void ProcessRequest(const Options& opts, RepoCache& cache, Request req) {
   ON_SCOPE_EXIT(=) {
     if (upstream) git_reference_free(upstream);
   };
+
+  // Remote name, e.g. "upstream" or "origin".
+  Remote remote = GetRemote(repo->repo(), upstream);
+
   // Upstream branch name.
-  resp.Print(upstream ? RemoteBranchName(repo->repo(), upstream) : "");
+  resp.Print(remote.branch);
+
+  // Remote Name; e.g. "upstream" or "origin"
+  resp.Print(remote.name);
 
   // Remote url.
   resp.Print(upstream ? RemoteUrl(repo->repo(), upstream) : "");


### PR DESCRIPTION
Here it is. This exports the remote name as `VCS_STATUS_REMOTE_NAME`.

#### What could be done better

- Currently the `VCS_STATUS_REMOTE_NAME` is appended as field 14. My OCD triggers a bit, because it belongs together with the remote url and remote branch (somwhere in the middle). I left it like that anyway, because this is an internal detail.

- I removed freeing the memory (`ON_SCOPE_EXIT(&) { git_buf_free(&remote); };`), because it hindered me of passing that variable around. Hopefully this was the right way to do it, and I did not produce a memory leak here.. 

- Stripping the remote name from the branch in `RemoteBranchName` seems a bit odd. Maybe we could find a better place for that.

#### What I struggled with

- The comfort of `./build.zsh`. This looks pretty innocent, but I tripped over it cloning the original sources of gitstatus. Haven't seen that in the first place, and wondered why my changes never showed up.. Had to change it, so that it copies the local sources over and compiles them..

- Out of nescience I plastered the code with `LOG(INFO)` Statements. Dunno if there is a better way, or how to increase the loglevel (the determined values would be interesting for a DEBUG log).

