### PR TITLE
listdir docs: fix v5 memcmp too large size

### DIFF
--- a/docs/listdir.md
+++ b/docs/listdir.md
@@ -286,7 +286,7 @@ void ListDir(int parent_fd, Arena& arena, vector<char*>& entries) {
   sort(entries.begin(), entries.end(), [](const char* a, const char* b) {
     uint64_t x = Read64(a);                                                               // +
     uint64_t y = Read64(b);                                                               // +
-    return x < y || (x == y && a != b && memcmp(a + 5, b + 5, 256) < 0);                  // +
+    return x < y || (x == y && a != b && memcmp(a + 5, b + 5, 255 - 5) < 0);              // +
   });
   for (char* p : entries) ByteSwap64(p);                                                  // +
   close(dir_fd);


### PR DESCRIPTION
Great writeup! 

I think I spotted a small issue. If we shift up by 5 bytes here, we should also stop looking 5 bytes sooner, else we'll read past the end. And change the base from 256 to 255 since that's the max path size (as correctly specified in line 241).