### PR TITLE
some typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ produce output in the same format. It does perform the same computation though.
 
 The following benchmark results were obtained on Intel i9-7900X running Ubuntu 18.04 in
 a clean [chromium](https://github.com/chromium/chromium) repository synced to `9394e49a`. The
-repository was checked out to an ext4 filesysem on M.2 SSD.
+repository was checked out to an ext4 filesystem on M.2 SSD.
 
 Three functionally equivalent tools for computing git status were benchmarked:
 
@@ -181,7 +181,7 @@ files) -- that's 25k `stat()` calls that could be avoided. The second reason is 
 gitstatusd use different flavors of `stat()`. libgit2 uses `lstat()`, which takes a path to the file
 as input. Its performance is linear in the number of subdirectories in the path because it needs to
 perform a lookup for every one of them and to check permissions. gitstatusd uses `fstatat()`, which
-takes a file destriptor to the parent directory and a name of the file. Just a single lookup, less
+takes a file descriptor to the parent directory and a name of the file. Just a single lookup, less
 CPU time.
 
 Similarly to `lstat()` vs `fstatat()`, it's faster to open files and directories with `openat()`
@@ -191,7 +191,7 @@ of the directories (this depends on the actual directory structure of the reposi
 immediate parent -- the most efficient way -- and the remaining 10% it opens from the repository's
 root directory. The reason it's done this way is to keep the maximum number of simultaneously open
 file descriptors bounded. libgit2 can have O(repository depth) simultaneously open file descriptors,
-which may be OK for a single-threaded application but can baloon to a large number when scans are
+which may be OK for a single-threaded application but can balloon to a large number when scans are
 done by many threads simultaneously, like in gitstatusd.
 
 There is no equivalent to `__opendir` or `__readdir` in the gitstatusd profile because it uses the

--- a/docs/listdir.md
+++ b/docs/listdir.md
@@ -67,7 +67,7 @@ void ListDir(const char* dirname, string& arena, vector<char*>& entries) {  // +
 }
 ```
 
-To make performance comparions easier, we can normalize them relative to the baseline. v1 will get
+To make performance comparison easier, we can normalize them relative to the baseline. v1 will get
 performance score of 100. A twice-as-fast alternative will be 200.
 
 | version |     optimization           |     score |
@@ -82,7 +82,7 @@ will fend off the occasional frontend developer who accidentally wanders into th
 
 `opendir()` is an expensive call whose performance is linear in the number of subdirectories in the
 path because it needs to perform a lookup for every one of them. We can replace it with `openat()`,
-which takes a file destriptor to the parent directory and a name of the subdirectory. Just a single
+which takes a file descriptor to the parent directory and a name of the subdirectory. Just a single
 lookup, less CPU time. This optimization assumes that callers already have a descriptor to the
 parent directory, which is indeed the case for gitstatusd, and is often the case in other
 applications that traverse filesystem.
@@ -133,7 +133,7 @@ documents the bare kernel system call interfaces.
 Note: There are no glibc wrappers for these system calls.
 ```
 
-Hm... The API looks like something we can take advantage of, so let's try it anyway.
+Hmm... The API looks like something we can take advantage of, so let's try it anyway.
 
 First, we'll need a simple `Arena` class that can allocate 8KB blocks of memory.
 


### PR DESCRIPTION
fixing typos in `README.md` and `docs/listdir.md`