### PR TITLE
- fix gitstatus load blocking alias

### DIFF
--- a/gitstatus.plugin.zsh
+++ b/gitstatus.plugin.zsh
@@ -508,5 +508,5 @@ function gitstatus_check() {
   [[ -n ${(P)${:-GITSTATUS_DAEMON_PID_${1}}} ]]
 }
 
-(( ! p9k_lean_restore_aliases )) || setopt aliases
-'builtin' 'unset' 'p9k_lean_restore_aliases'
+(( ! _gitstatus_restore_aliases )) || setopt aliases
+'builtin' 'unset' '_gitstatus_restore_aliases'


### PR DESCRIPTION
Commit c71da74b4a6c50728c108933eeda94533680ed97 break aliases when loading this file.

This patch should re-enable the alias option correctly