### PR TITLE
Add missing -c to gitstatus_start() in plugin.zsh

### DIFF
--- a/gitstatus.plugin.zsh
+++ b/gitstatus.plugin.zsh
@@ -273,7 +273,7 @@ function gitstatus_start() {
   local -i max_num_untracked=1
   local -i dirty_max_index_size=-1
   while true; do
-    getopts "t:s:u:d:m:" opt || break
+    getopts "t:s:u:c:d:m:" opt || break
     case $opt in
       t) timeout=$OPTARG;;
       s) max_num_staged=$OPTARG;;


### PR DESCRIPTION
When the option as added in 6c170cb it wasn't added to the getopt
invocation so it wasn't actually possible to pass it.