### PR TITLE
gitstatus_start_impl: declare os variable.

### DIFF
--- a/gitstatus.plugin.zsh
+++ b/gitstatus.plugin.zsh
@@ -371,7 +371,8 @@ function gitstatus_start() {
     }
 
     (( daemon_pid == -1 )) || {
-      local daemon=${GITSTATUS_DAEMON:-} os
+      local os
+      local daemon=${GITSTATUS_DAEMON:-}
       [[ -n $daemon ]] || {
         os="$(uname -s)" && [[ -n $os ]]
         [[ $os != Linux || "$(uname -o)" != Android ]] || os=Android


### PR DESCRIPTION
When the os variable isn't declared I get the following error on
initialization:

> gitstatus_start_impl:28: os: parameter not set

The error is raised by the following line:

    [[ -n $os ]] || { os="$(uname -s)" && [[ -n $os ]] }