### PR TITLE
build.zsh: Fix build for android-armv7l

### DIFF
--- a/build.zsh
+++ b/build.zsh
@@ -85,6 +85,7 @@ function build_gitstatus() {
   case $OS in
     Android)
       cxx=${CXX:-'clang++'}
+      ldflags=" -latomic"
       ;;
     Linux)
       ldflags+=" -static-libstdc++ -static-libgcc"


### PR DESCRIPTION
Refrence: https://github.com/termux/termux-packages/issues/3092

Binary PR here: https://github.com/romkatv/gitstatus/pull/96