### PR TITLE
add fish bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,18 @@ script that uses these bindings to assemble git prompt.
 
 Note: Bash bindings, unlike ZSH bindings, don't support asynchronous calls.
 
+## Using from fish
+
+Install with [Fisher](https://github.com/jorgebucaran/fisher):
+
+```fish
+fisher add romkatv/gitstatus
+```
+
+It ships with a prompt function which add git status prompt to fish's default prompt.
+You could also use functions `gitstatus_prompt` or `gitstatus_query` to write your
+custom prompt function.
+
 ## Using from other shells
 
 If there are no gitstatusd bindings for your shell, you'll need to get your hands dirty.

--- a/_install_gitstatus.fish
+++ b/_install_gitstatus.fish
@@ -1,0 +1,26 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It's the fisher install script.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+if set -q pkg
+    set -U GITSTATUS_DIR "$pkg"
+    source "$pkg/gitstatus_start.fish"
+    source "$pkg/gitstatus_stop.fish"
+end
+
+if set -q target
+    command rm -f "$target" # remove itself
+end

--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,0 +1,37 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It provides fish prompt with git status.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+# Fish default prompt + gitstatus prompt
+
+function fish_prompt --description "Write out the prompt"
+    set -l color_cwd
+    set -l suffix
+    switch "$USER"
+        case root toor
+            if set -q fish_color_cwd_root
+                set color_cwd $fish_color_cwd_root
+            else
+                set color_cwd $fish_color_cwd
+            end
+            set suffix '#'
+        case '*'
+            set color_cwd $fish_color_cwd
+            set suffix '>'
+    end
+
+    echo -n -s "$USER" @ (prompt_hostname) ' ' (set_color $color_cwd) (prompt_pwd) (gitstatus_prompt) (set_color normal) "$suffix "
+end

--- a/gitstatus_prompt.fish
+++ b/gitstatus_prompt.fish
@@ -1,0 +1,120 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It print prompt for fish to reflect git status.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+# Print GITSTATUS_PROMPT to reflect the state of the current git repository.
+# The value is empty if not in a git repository. Forwards all arguments to
+# gitstatus_query.
+#
+# Example value of GITSTATUS_PROMPT:
+#
+#   master+!? ⇡2 ⇣3 *4
+#
+# Meaning:
+#
+#   master   current branch
+#   +        git repo has changes staged for commit
+#   !        git repo has unstaged changes
+#   ?        git repo has untracked files
+#   ⇡2       local branch is ahead of origin by 2 commits
+#   ⇣3       local branch is behind origin by 3 commits
+#   *4       git repo has 4 stashes
+
+function gitstatus_prompt
+    set -l IFS
+
+    gitstatus_query $argv; or return 1 # error
+    test "$VCS_STATUS_RESULT" = ok-sync; or return 0 # not a git repo
+
+    set -l color_reset normal
+    set -l color_clean green
+    set -l color_untracked cyan
+    set -l color_modified yellow
+    set -l color_conflicted red
+
+    set_color $color_reset
+    echo -n ' '
+
+    set -l where
+    if test -n "$VCS_STATUS_LOCAL_BRANCH"
+        set where "$VCS_STATUS_LOCAL_BRANCH"
+    else if test -n "$VCS_STATUS_TAG"
+        set_color $color_reset
+        echo -n '#'
+        set where "$VCS_STATUS_TAG"
+    else
+        set_color $color_reset
+        echo -n '@'
+        set where (string sub -l 8 "$VCS_STATUS_COMMIT")
+    end
+
+    if test (string length "$where") -gt 32
+        # truncate long branch names and tags
+        set where (string sub -l 12 "$where")…(string sub -s -12 "$where")
+    end
+
+    set_color $color_clean
+    echo -n $where
+
+    # ⇣42 if behind the remote.
+    if test "$VCS_STATUS_COMMITS_BEHIND" -gt 0
+        set_color $color_clean
+        echo -n " ⇣$VCS_STATUS_COMMITS_BEHIND"
+    end
+    # ⇡42 if ahead of the remote; no leading space if also behind the remote: ⇣42⇡42.
+    if test "$VCS_STATUS_COMMITS_AHEAD" -gt 0
+        test "$VCS_STATUS_COMMITS_BEHIND" -gt 0; or echo -n ' '
+        set_color $color_clean
+        echo -n "⇡$VCS_STATUS_COMMITS_AHEAD"
+    end
+    # *42 if have stashes.
+    if test "$VCS_STATUS_STASHES" -gt 0
+        set_color $color_clean
+        echo -n " *$VCS_STATUS_STASHES"
+    end
+    # 'merge' if the repo is in an unusual state.
+    if test -n "$VCS_STATUS_ACTION"
+        set_color $color_conflicted
+        echo -n " $VCS_STATUS_ACTION"
+    end
+    # ~42 if have merge conflicts.
+    if test "$VCS_STATUS_NUM_CONFLICTED" -gt 0
+        set_color $color_conflicted
+        echo -n " ~$VCS_STATUS_NUM_CONFLICTED"
+    end
+    # +42 if have staged changes.
+    if test "$VCS_STATUS_NUM_STAGED" -gt 0
+        set_color $color_modified
+        echo -n " +$VCS_STATUS_NUM_STAGED"
+    end
+    # !42 if have unstaged changes.
+    if test "$VCS_STATUS_NUM_UNSTAGED" -gt 0
+        set_color $color_modified
+        echo -n " !$VCS_STATUS_NUM_UNSTAGED"
+    end
+    # ?42 if have untracked files. It's really a question mark, your font isn't broken.
+    if test "$VCS_STATUS_NUM_UNTRACKED" -gt 0
+        set_color $color_untracked
+        echo -n " !$VCS_STATUS_NUM_UNTRACKED"
+    end
+
+    set_color $color_reset
+    return 0
+end
+
+# Start gitstatusd in the background.
+gitstatus_stop
+gitstatus_start -s -1 -u -1 -c -1 -d -1

--- a/gitstatus_query.fish
+++ b/gitstatus_query.fish
@@ -1,0 +1,210 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It provides fish bindings.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+function gitstatus_query --description='Retrives status of a git repository'
+    set -l IFS
+    test -n "$TMPDIR"; or set -l TMPDIR /tmp
+
+    argparse --name=gitstatus_start \
+             --max-args=0 \
+             'd/dir=' \
+             't/timeout=' \
+             'p/no-diff' \
+             'h/help' \
+             -- $argv
+    or begin
+        _gitstatus_query_usage
+        return 1
+    end
+    if set -q _flag_help
+        _gitstatus_query_help
+        return 0
+    end
+
+    set -q GITSTATUS_DAEMON_PID; or return # not started
+
+    set -l req_id (random).(random).(random).(random)
+
+    set -l dir "."
+    set -q _flag_dir; and set dir "$_flag_dir"
+    test -n "$GIT_DIR"; and set dir "$GIT_DIR"
+    set dir (realpath "$dir")
+
+    set -l timeout
+    set -q _flag_timeout; and set timeout -t "$_flag_timeout"
+
+    set -l no_diff 0
+    set -q _flag_no_diff; and set no_diff 1
+
+    # Fish currently doesn't support `read` with timeout, use netcat's timeout instead.
+    # (See the issue https://github.com/fish-shell/fish-shell/issues/1134)
+    set -l resp_fifo (mktemp -u "$TMPDIR/gitstatus.$fish_pid.pipe.tmp.XXXXXXXXXX"); or return
+    mkfifo "$resp_fifo"; or return
+    set -lx _gitstatus_req $req_id\x1f$dir\x1f$no_diff\x1e
+    set -l resp (fish -c 'echo -n $_gitstatus_req; expect -c "expect \x1e"' < "$resp_fifo" |
+                 nc -U "$GITSTATUS_SOCK" $timeout 2> /dev/null | tee "$resp_fifo")
+    command rm "$resp_fifo"; or return
+
+    test -n "$resp"; or return
+    test (string sub -s -1 "$resp") = \x1e; or return
+    string trim -rc \x1e "$resp" | read -zad \x1f resp
+    test "$resp[1]" = "$req_id"; or return
+
+    if test "$resp[2]" = 1
+        set -g VCS_STATUS_RESULT ok-sync
+        set -g VCS_STATUS_WORKDIR "$resp[3]"
+        set -g VCS_STATUS_COMMIT "$resp[4]"
+        set -g VCS_STATUS_LOCAL_BRANCH "$resp[5]"
+        set -g VCS_STATUS_REMOTE_BRANCH "$resp[6]"
+        set -g VCS_STATUS_REMOTE_NAME "$resp[7]"
+        set -g VCS_STATUS_REMOTE_URL "$resp[8]"
+        set -g VCS_STATUS_ACTION "$resp[9]"
+        set -g VCS_STATUS_INDEX_SIZE "$resp[10]"
+        set -g VCS_STATUS_NUM_STAGED "$resp[11]"
+        set -g VCS_STATUS_NUM_UNSTAGED "$resp[12]"
+        set -g VCS_STATUS_NUM_CONFLICTED "$resp[13]"
+        set -g VCS_STATUS_NUM_UNTRACKED "$resp[14]"
+        set -g VCS_STATUS_COMMITS_AHEAD "$resp[15]"
+        set -g VCS_STATUS_COMMITS_BEHIND "$resp[16]"
+        set -g VCS_STATUS_STASHES "$resp[17]"
+        set -g VCS_STATUS_TAG "$resp[18]"
+        set -g VCS_STATUS_NUM_UNSTAGED_DELETED "$resp[19]"
+        set -g VCS_STATUS_NUM_STAGED_NEW 0
+        set -q resp[20]; and set VCS_STATUS_NUM_STAGED_NEW "$resp[20]"
+        set -g VCS_STATUS_NUM_STAGED_DELETED 0
+        set -q resp[21]; and set VCS_STATUS_NUM_STAGED_DELETED "$resp[21]"
+        set -g VCS_STATUS_PUSH_REMOTE_NAME "$resp[22]"
+        set -g VCS_STATUS_PUSH_REMOTE_URL "$resp[23]"
+        set -g VCS_STATUS_PUSH_COMMITS_AHEAD 0
+        set -q resp[24]; and set VCS_STATUS_PUSH_COMMITS_AHEAD "$resp[24]"
+        set -g VCS_STATUS_PUSH_COMMITS_BEHIND 0
+        set -q resp[25]; and set VCS_STATUS_PUSH_COMMITS_BEHIND "$resp[25]"
+        set -g VCS_STATUS_HAS_STAGED 0
+        test "$VCS_STATUS_NUM_STAGED" -gt 0; and set VCS_STATUS_HAS_STAGED 1
+        if test "$GITSTATUS_DIRTY_MAX_INDEX_SIZE" -ge 0 \
+            -a "$VCS_STATUS_INDEX_SIZE" -gt "$GITSTATUS_DIRTY_MAX_INDEX_SIZE"
+            set -g VCS_STATUS_HAS_UNSTAGED -1
+            set -g VCS_STATUS_HAS_CONFLICTED -1
+            set -g VCS_STATUS_HAS_UNTRACKED -1
+        else
+            set -g VCS_STATUS_HAS_UNSTAGED 0
+            test "$VCS_STATUS_NUM_UNSTAGED" -gt 0; and set VCS_STATUS_HAS_UNSTAGED 1
+            set -g VCS_STATUS_HAS_CONFLICTED 0
+            test "$VCS_STATUS_NUM_CONFLICTED" -gt 0; and set VCS_STATUS_HAS_CONFLICTED 1
+            set -g VCS_STATUS_HAS_UNTRACKED 0
+            test "$VCS_STATUS_NUM_UNTRACKED" -gt 0; and set VCS_STATUS_HAS_UNTRACKED 1
+        end
+    else
+        set -g VCS_STATUS_RESULT norepo-sync
+        set -e VCS_STATUS_WORKDIR
+        set -e VCS_STATUS_COMMIT
+        set -e VCS_STATUS_LOCAL_BRANCH
+        set -e VCS_STATUS_REMOTE_BRANCH
+        set -e VCS_STATUS_REMOTE_NAME
+        set -e VCS_STATUS_REMOTE_URL
+        set -e VCS_STATUS_ACTION
+        set -e VCS_STATUS_INDEX_SIZE
+        set -e VCS_STATUS_NUM_STAGED
+        set -e VCS_STATUS_NUM_UNSTAGED
+        set -e VCS_STATUS_NUM_CONFLICTED
+        set -e VCS_STATUS_NUM_UNTRACKED
+        set -e VCS_STATUS_HAS_STAGED
+        set -e VCS_STATUS_HAS_UNSTAGED
+        set -e VCS_STATUS_HAS_CONFLICTED
+        set -e VCS_STATUS_HAS_UNTRACKED
+        set -e VCS_STATUS_COMMITS_AHEAD
+        set -e VCS_STATUS_COMMITS_BEHIND
+        set -e VCS_STATUS_STASHES
+        set -e VCS_STATUS_TAG
+        set -e VCS_STATUS_NUM_UNSTAGED_DELETED
+        set -e VCS_STATUS_NUM_STAGED_NEW
+        set -e VCS_STATUS_NUM_STAGED_DELETED
+        set -e VCS_STATUS_PUSH_REMOTE_NAME
+        set -e VCS_STATUS_PUSH_REMOTE_URL
+        set -e VCS_STATUS_PUSH_COMMITS_AHEAD
+        set -e VCS_STATUS_PUSH_COMMITS_BEHIND
+    end
+
+    return 0
+end
+
+function _gitstatus_query_usage
+    echo 'Usage: gitstatus_query [-ph] [-d STR] [-t FLOAT] [--help]'
+end
+
+function _gitstatus_query_help
+    _gitstatus_query_usage
+    echo
+    echo '  -d STR    Directory to query. Defaults to $PWD. Has no effect if GIT_DIR is set.'
+    echo '  -t FLOAT  Timeout in seconds. Will block for at most this long. If no results'
+    echo '            are available by then, will return error.'
+    echo '  -p        Don\'t compute anything that requires reading Git index. If this option is used,'
+    echo '            the following parameters will be 0: VCS_STATUS_INDEX_SIZE,'
+    echo '            VCS_STATUS_{NUM,HAS}_{STAGED,UNSTAGED,UNTRACKED,CONFLICTED}.'
+    echo
+    echo 'On success sets VCS_STATUS_RESULT to one of the following values:'
+    echo
+    echo '  norepo-sync  The directory doesn\'t belong to a git repository.'
+    echo '  ok-sync      The directory belongs to a git repository.'
+    echo
+    echo 'If VCS_STATUS_RESULT is ok-sync, additional variables are set:'
+    echo
+    echo '  VCS_STATUS_WORKDIR              Git repo working directory. Not empty.'
+    echo '  VCS_STATUS_COMMIT               Commit hash that HEAD is pointing to. Either 40 hex digits or'
+    echo '                                  empty if there is no HEAD (empty repo).'
+    echo '  VCS_STATUS_LOCAL_BRANCH         Local branch name or empty if not on a branch.'
+    echo '  VCS_STATUS_REMOTE_NAME          The remote name, e.g. "upstream" or "origin".'
+    echo '  VCS_STATUS_REMOTE_BRANCH        Upstream branch name. Can be empty.'
+    echo '  VCS_STATUS_REMOTE_URL           Remote URL. Can be empty.'
+    echo '  VCS_STATUS_ACTION               Repository state, A.K.A. action. Can be empty.'
+    echo '  VCS_STATUS_INDEX_SIZE           The number of files in the index.'
+    echo '  VCS_STATUS_NUM_STAGED           The number of staged changes.'
+    echo '  VCS_STATUS_NUM_CONFLICTED       The number of conflicted changes.'
+    echo '  VCS_STATUS_NUM_UNSTAGED         The number of unstaged changes.'
+    echo '  VCS_STATUS_NUM_UNTRACKED        The number of untracked files.'
+    echo '  VCS_STATUS_HAS_STAGED           1 if there are staged changes, 0 otherwise.'
+    echo '  VCS_STATUS_HAS_CONFLICTED       1 if there are conflicted changes, 0 otherwise.'
+    echo '  VCS_STATUS_HAS_UNSTAGED         1 if there are unstaged changes, 0 if there aren\'t, -1 if'
+    echo '                                  unknown.'
+    echo '  VCS_STATUS_NUM_STAGED_NEW       The number of staged new files. Note that renamed files'
+    echo '                                  are reported as deleted plus new.'
+    echo '  VCS_STATUS_NUM_STAGED_DELETED   The number of staged deleted files. Note that renamed files'
+    echo '                                  are reported as deleted plus new.'
+    echo '  VCS_STATUS_NUM_UNSTAGED_DELETED The number of unstaged deleted files. Note that renamed files'
+    echo '                                  are reported as deleted plus new.'
+    echo '  VCS_STATUS_HAS_UNTRACKED        1 if there are untracked files, 0 if there aren\'t, -1 if'
+    echo '                                  unknown.'
+    echo '  VCS_STATUS_COMMITS_AHEAD        Number of commits the current branch is ahead of upstream.'
+    echo '                                  Non-negative integer.'
+    echo '  VCS_STATUS_COMMITS_BEHIND       Number of commits the current branch is behind upstream.'
+    echo '                                  Non-negative integer.'
+    echo '  VCS_STATUS_STASHES              Number of stashes. Non-negative integer.'
+    echo '  VCS_STATUS_TAG                  The last tag (in lexicographical order) that points to the same'
+    echo '                                  commit as HEAD.'
+    echo '  VCS_STATUS_PUSH_REMOTE_NAME     The push remote name, e.g. "upstream" or "origin".'
+    echo '  VCS_STATUS_PUSH_REMOTE_URL      Push remote URL. Can be empty.'
+    echo '  VCS_STATUS_PUSH_COMMITS_AHEAD   Number of commits the current branch is ahead of push remote.'
+    echo '                                  Non-negative integer.'
+    echo '  VCS_STATUS_PUSH_COMMITS_BEHIND  Number of commits the current branch is behind push remote.'
+    echo '                                  Non-negative integer.'
+    echo
+    echo 'The point of reporting -1 via VCS_STATUS_HAS_* is to allow the command to skip scanning files in'
+    echo 'large repos. See -m flag of gitstatus_start.'
+    echo
+    echo 'gitstatus_query returns an error if gitstatus_start hasn\'t been called in the same'
+    echo 'shell or the call had failed.'
+end

--- a/gitstatus_start.fish
+++ b/gitstatus_start.fish
@@ -1,0 +1,213 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It provides fish bindings.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+functions -q gitstatus_stop
+function gitstatus_start --description='Starts gitstatusd in the background'
+    set -l IFS
+    test -n "$TMPDIR"; or set -l TMPDIR /tmp
+
+    argparse --name=gitstatus_start \
+             --max-args=0 \
+             't/timeout=' \
+             's/max-num-staged=' \
+             'u/max-num-unstaged=' \
+             'c/max-num-conflicted=' \
+             'd/max-num-untracked=' \
+             'm/max-dirty=' \
+             'e/recurse-untracked-dirs' \
+             'U/ignore-status-show-untracked-files' \
+             'W/ignore-bash-show-untracked-files' \
+             'D/ignore-bash-show-dirty-state' \
+             'h/help' \
+             -- $argv
+    or begin
+        _gitstatus_start_usage
+        return 1
+    end
+    if set -q _flag_help
+        _gitstatus_start_help
+        return 0
+    end
+
+    set -q _flag_timeout; or set -l _flag_timeout 5
+    set -q _flag_max_num_staged; or set -l _flag_max_num_staged 1
+    set -q _flag_max_num_unstaged; or set -l _flag_max_num_unstaged 1
+    set -q _flag_max_num_conflicted; or set -l _flag_max_num_conflicted 1
+    set -q _flag_max_num_untracked; or set -l _flag_max_num_untracked 1
+    set -q _flag_max_dirty; or set -l _flag_max_dirty -1
+
+    set -q GITSTATUS_DAEMON_PID
+    and return # already started
+
+    set -q GITSTATUS_DIR
+    or set -l GITSTATUS_DIR (dirname (realpath (status filename)))
+
+    function gitstatus_start_impl --no-scope-shadowing
+        set -l log_level "$GITSTATUS_LOG_LEVEL"
+        if test -z "$log_level" -a "$GITSTATUS_ENABLE_LOGGING" = 1
+            set log_level INFO
+        end
+
+        set -l daemon "$GITSTATUS_DAEMON"
+        set -l os (uname -s); or return
+        if test -z "$daemon"
+            set -l arch (uname -m); or return
+            if test "$os" = Linux
+                set -l uname_o (uname -o)
+                if test "$uname_o" = Android
+                    set os Android
+                end
+            end
+            if string match -qri '(msys|mingw).*' "$os"
+                set os msys_nt-10.0
+            end
+            set daemon "$GITSTATUS_DIR/bin/gitstatusd-"(string lower "$os")-(string lower "$arch")
+        end
+
+        set -l threads "$GITSTATUS_NUM_THREADS"
+        if test -z "$threads" -o "$threads" -le 0
+            switch $os
+                case FreeBSD
+                    set threads (sysctl -n hw.ncpu)
+                case '*'
+                    set threads (getconf _NPROCESSORS_ONLN)
+            end
+            set threads (math "$threads * 2")
+            test "$threads" -ge 2; or set threads 2
+            test "$threads" -le 32; or set threads 32
+        end
+
+        set -l daemon_args \
+            --parent-pid="$fish_pid" \
+            --num-threads="$threads" \
+            --max-num-staged="$_flag_max_num_staged" \
+            --max-num-unstaged="$_flag_max_num_unstaged" \
+            --max-num-untracked="$_flag_max_num_untracked" \
+            --dirty-max-index-size="$_flag_max_dirty"
+        if set -q _flag_recurse_untracked_dirs
+            set daemon_args $daemon_args --recurse-untracked-dirs
+        end
+        if set -q _flag_ignore_status_show_untracked_files
+            set daemon_args $daemon_args --ignore-status-show-untracked-files
+        end
+        if set -q _flag_ignore_bash_show_untracked_files
+            set daemon_args $daemon_args --ignore-bash-show-untracked-files
+        end
+        if set -q _flag_ignore_bash_show_dirty_state
+            set daemon_args $daemon_args --ignore-bash-show-dirty-state
+        end
+
+        if test -n "$log_level"
+            set -g GITSTATUS_DAEMON_LOG (mktemp "$TMPDIR/gitstatus.$fish_pid.log.XXXXXXXXXX")
+            or return
+            if test "$log_level" = INFO
+                set daemon_args $daemon_args --log-level="$log_level"
+            end
+        else
+            set -g GITSTATUS_DAEMON_LOG /dev/null
+        end
+
+        string match -qr '[a-zA-Z0-9=-]*' -- "$daemon_args"; or return
+
+        set -g req_fifo (mktemp -u "$TMPDIR/gitstatus.$fish_pid.pipe.req.XXXXXXXXXX"); or return
+        set -g resp_fifo (mktemp -u "$TMPDIR/gitstatus.$fish_pid.pipe.resp.XXXXXXXXXX"); or return
+        set -g GITSTATUS_SOCK (mktemp -u "$TMPDIR/gitstatus.$fish_pid.sock.XXXXXXXXXX"); or return
+        mkfifo "$req_fifo" "$resp_fifo"; or return
+
+        set -lx _gitstatus_daemon "$daemon"
+        fish -c (echo 'trap "kill %1 2>/dev/null" SIGINT SIGTERM EXIT'
+                 echo 'status job-control full'
+                 echo '$_gitstatus_daemon' $daemon_args '<&3 >&4 &'
+                 echo 'wait %1'
+                 echo 'if test "$status" -ne 0 -a "$status" -ne 10 -a "$status" -le 128' \
+                 '    -a -f $_gitstatus_daemon-static'
+                 echo '    $_gitstatus_daemon-static' $daemon_args '<&3 >&4 &'
+                 echo '    wait %1'
+                 echo 'end'
+                 echo 'echo -n bye\x1f0\x1e >&4') \
+            > "$GITSTATUS_DAEMON_LOG" 2>&1 3< "$req_fifo" 4> "$resp_fifo" &
+        set -g GITSTATUS_DAEMON_PID (jobs -lp)
+
+        # Fish currently doesn't support setting redirection for the current shell,
+        # which can be done in bash by running `exec` only with redirection.
+        # (See the issue https://github.com/fish-shell/fish-shell/issues/3948)
+        # As walkaround, we use netcat to redirect fifo to a unix socket.
+        begin nc -lkU "$GITSTATUS_SOCK" & end > "$req_fifo" < "$resp_fifo" 2> /dev/null
+        set -g GITSTATUS_NC_PID (jobs -lp)
+
+        disown $GITSTATUS_DAEMON_PID $GITSTATUS_NC_PID
+        command rm "$req_fifo" "$resp_fifo"; or return
+
+        # Fish currently doesn't support `read` with timeout, use netcat's timeout instead.
+        # (See the issue https://github.com/fish-shell/fish-shell/issues/1134)
+        set -l resp_fifo (mktemp -u "$TMPDIR/gitstatus.$fish_pid.pipe.tmp.XXXXXXXXXX"); or return
+        mkfifo "$resp_fifo"; or return
+        set -l resp (fish -c 'echo -n hello\x1f\x1e; expect -c "expect \x1e"' < "$resp_fifo" |
+                     nc -U "$GITSTATUS_SOCK" -w "$_flag_timeout" 2> /dev/null | tee "$resp_fifo")
+        command rm "$resp_fifo"; or return
+        test "$resp" = hello\x1f0\x1e; or return
+
+        set -g GITSTATUS_DIRTY_MAX_INDEX_SIZE "$_flag_max_dirty"
+    end
+
+    if not gitstatus_start_impl
+        echo 'gitstatus_start: failed to start gitstatusd' >&2
+        functions -e gitstatus_start_impl
+        gitstatus_stop
+        return 1
+    end
+
+    functions -e gitstatus_start_impl
+    return 0
+end
+
+function _gitstatus_start_usage
+    echo 'Usage: gitstatus_start [-eUWDh] [-t FLOAT] [-s INT] [-u INT] [-c INT] [-d INT] [-m INT] [--help]'
+end
+
+function _gitstatus_start_help
+    _gitstatus_start_usage
+    echo
+    echo '  -t FLOAT  Fail the self-check on initialization if not getting a response from'
+    echo '            gitstatusd for this this many seconds. Defaults to 5.'
+    echo
+    echo '  -s INT    Report at most this many staged changes; negative value means infinity.'
+    echo '            Defaults to 1.'
+    echo
+    echo '  -u INT    Report at most this many unstaged changes; negative value means infinity.'
+    echo '            Defaults to 1.'
+    echo
+    echo '  -c INT    Report at most this many conflicted changes; negative value means infinity.'
+    echo '            Defaults to 1.'
+    echo
+    echo '  -d INT    Report at most this many untracked files; negative value means infinity.'
+    echo '            Defaults to 1.'
+    echo
+    echo '  -m INT    Report -1 unstaged, untracked and conflicted if there are more than this many'
+    echo '            files in the index. Negative value means infinity. Defaults to -1.'
+    echo
+    echo '  -e        Count files within untracked directories like `git status --untracked-files`.'
+    echo
+    echo '  -U        Unless this option is specified, report zero untracked files for repositories'
+    echo '            with status.showUntrackedFiles = false.'
+    echo
+    echo '  -W        Unless this option is specified, report zero untracked files for repositories'
+    echo '            with bash.showUntrackedFiles = false.'
+    echo
+    echo '  -D        Unless this option is specified, report zero staged, unstaged and conflicted'
+    echo '            changes for repositories with bash.showDirtyState = false.'
+end

--- a/gitstatus_stop.fish
+++ b/gitstatus_stop.fish
@@ -1,0 +1,29 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It provides fish bindings.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+function gitstatus_stop --description='Stop gitstatusd if it is running' --on-event fish_exit
+    set -q GITSTATUS_DAEMON_PID; and kill "$GITSTATUS_DAEMON_PID" 2> /dev/null
+    set -q GITSTATUS_NC_PID; and kill "$GITSTATUS_NC_PID" 2> /dev/null
+    set -q GITSTATUS_SOCK; and command rm -f "$GITSTATUS_SOCK"
+
+    set -e GITSTATUS_DAEMON_PID
+    set -e GITSTATUS_NC_PID
+    set -e GITSTATUS_SOCK
+    set -e GITSTATUS_DIRTY_MAX_INDEX_SIZE
+
+    return 0
+end

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -1,0 +1,24 @@
+# Copyright 2019 Roman Perepelitsa.
+#
+# This file is part of GitStatus. It's the fisher uninstall script.
+#
+# GitStatus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GitStatus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GitStatus. If not, see <https://www.gnu.org/licenses/>.
+
+if set -q pkg
+    source "$pkg/gitstatus_stop.fish"
+    gitstatus_stop
+    functions -e gitstatus_stop
+end
+
+set -Ue GITSTATUS_DIR


### PR DESCRIPTION
Basically translate from Bash bindings, but since fish doesn't support setting redirection for the current shell (which is `exec {_REQ_FD}>$req_fifo {_RESP_FD}<$resp_fifo` in bash) and `read` with timeout, a `netcat` process listening a unix socket is run in background, to redirect requests and responses, and use `nc -w $timeout` as the replacement of `read -t $timeout`. Could be improve if these two issues are solved https://github.com/fish-shell/fish-shell/issues/3948 https://github.com/fish-shell/fish-shell/issues/1134