### PR TITLE
fix gitstatus failing to start on MINGW* systems

### DIFF
--- a/gitstatus.plugin.zsh
+++ b/gitstatus.plugin.zsh
@@ -508,7 +508,7 @@ function gitstatus_start() {
                     [[ $os[1] == android ]]              || os=(linux)
                   ;;
                   cygwin_nt-*)  os=($kernel cygwin_nt-10.0);;
-                  mingw|msys)   os=($kernel msys_nt-10.0);;
+                  mingw*|msys*) os=($kernel msys_nt-10.0);;
                   *)            os=($kernel);;
                 esac
                 local arch


### PR DESCRIPTION
due to some missing wildcards in the kernel check, when msys2 is run with MSYSTEM set to either MINGW32 or MINGW64, gitstatus will fail to initialize while trying to look for the default (non-existent) daemon binary files. These wildcards are present in the corresponding sh script gitstatus.plugin.sh