### PR TITLE
build: no gpg sign

### DIFF
--- a/build
+++ b/build
@@ -269,7 +269,7 @@ command strip "$app".tmp
 command mkdir -- "$workdir"/repo
 command git -C "$workdir"/repo init --
 command git -C "$workdir"/repo config user.email "you@example.com"
-command git -C "$workdir"/repo commit --allow-empty --allow-empty-message -m ''
+command git -C "$workdir"/repo commit --allow-empty --allow-empty-message --no-gpg-sign -m ''
 
 resp="$(printf "hello\037$workdir/repo\036" | "$app".tmp)"
 [ -n "$resp" -a -z "${resp##hello*1*$workdir/repo*master*}" ]


### PR DESCRIPTION
If someone (like me) enable gpg sign globally, `./build -w` will fail due to gpg sign error.