### PR TITLE
Changed license for gitstatus.prompt.(z)sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,5 +525,7 @@ gitstatus are released. This may change in the future but not soon.
 
 ## License
 
-GNU General Public License v3.0. See [LICENSE](LICENSE). Contributions are covered by the same
+Most of the repository is covered by GNU General Public License v3.0. See [LICENSE](LICENSE). Contributions are covered by the same
 license.
+
+`gitstatus.prompt.sh` and `gitstatus.prompt.zsh` are part of the public domain.

--- a/gitstatus.prompt.sh
+++ b/gitstatus.prompt.sh
@@ -1,4 +1,5 @@
 # Simple Bash prompt with Git status.
+# No rights reserved for this file.
 
 # Source gitstatus.plugin.sh from $GITSTATUS_DIR or from the same directory
 # in which the current script resides if the variable isn't set.

--- a/gitstatus.prompt.zsh
+++ b/gitstatus.prompt.zsh
@@ -1,4 +1,5 @@
 # Simple Zsh prompt with Git status.
+# No rights reserved for this file.
 
 # Source gitstatus.plugin.zsh from $GITSTATUS_DIR or from the same directory
 # in which the current script resides if the variable isn't set.


### PR DESCRIPTION
https://opensource.stackexchange.com/a/2695

"The bottom line is to make sure recipients can easily figure out which files are under which license."