### PR TITLE
Support building on OpenBSD

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Type `build -h` for help and see https://github.com/romkatv/gitstatus
 # for full documentation.
@@ -90,6 +90,9 @@ if [ -n "$gitstatus_install_tools" ]; then
     freebsd)
       command pkg install -y cmake gmake binutils gcc git perl5
     ;;
+    openbsd)
+      command pkg_add install cmake gmake gcc git wget
+    ;;
     netbsd)
       command pkgin -y install cmake gmake binutils git
     ;;
@@ -155,6 +158,13 @@ case "$gitstatus_kernel" in
     libgit2_cmake_flags="$libgit2_cmake_flags -DENABLE_REPRODUCIBLE_BUILDS=ON"
   ;;
   freebsd)
+    gitstatus_make=gmake
+    gitstatus_ldflags="$gitstatus_ldflags -static"
+    gitstatus_ldflags="$gitstatus_ldflags -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
+    libgit2_cmake_flags="$libgit2_cmake_flags -DENABLE_REPRODUCIBLE_BUILDS=ON"
+  ;;
+  openbsd)
+    gitstatus_cxx=eg++
     gitstatus_make=gmake
     gitstatus_ldflags="$gitstatus_ldflags -static"
     gitstatus_ldflags="$gitstatus_ldflags -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"
@@ -473,7 +483,7 @@ case "$gitstatus_kernel" in
       fi
     fi
   ;;
-  freebsd|netbsd|darwin)
+  freebsd|openbsd|netbsd|darwin)
     if [ -n "$docker_cmd" ]; then
       >&2 echo "[error] docker (-d) is not supported on $gitstatus_kernel"
       exit 1

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Type `build -h` for help and see https://github.com/romkatv/gitstatus
 # for full documentation.


### PR DESCRIPTION
OpenBSD is similar to FreeBSD and NetBSD with a few exceptions: packages are installed with pkg_add, g++ is eg++, and it matters that /bin/sh is not bash.