### PR TITLE
Fix `gitstatusd: option does not take an argument: version-glob`

### DIFF
--- a/src/options.cc
+++ b/src/options.cc
@@ -239,7 +239,7 @@ const char* Version() {
 Options ParseOptions(int argc, char** argv) {
   const struct option opts[] = {{"help", no_argument, nullptr, 'h'},
                                 {"version", no_argument, nullptr, 'V'},
-                                {"version-glob", no_argument, nullptr, 'G'},
+                                {"version-glob", required_argument, nullptr, 'G'},
                                 {"lock-fd", required_argument, nullptr, 'l'},
                                 {"parent-pid", required_argument, nullptr, 'p'},
                                 {"num-threads", required_argument, nullptr, 't'},


### PR DESCRIPTION
The short version of this flag `-G` works properly, but long version does not.

```
$ gitstatusd --version-glob='v1.3.*'
gitstatusd: option does not take an argument: version-glob

$ gitstatusd --version-glob '1.3.*'
Segmentation fault (core dumped)
```

Note: I usually don't write C++ codes so I cannot read the code carefully. Because this is kinda typo fix, please feel free to close this PR.