### PR TITLE
Aliasing "exec" and "builtin" causes various problems. Can you turn it off by default?

### DIFF
--- a/gitstatus.plugin.sh
+++ b/gitstatus.plugin.sh
@@ -266,7 +266,7 @@ function gitstatus_start() {
 
   unset -f gitstatus_start_impl
 
-  if [[ "${GITSTATUS_STOP_ON_EXEC:-1}" == 1 ]]; then
+  if [[ "${GITSTATUS_STOP_ON_EXEC:-0}" == 1 ]]; then
     type -t _gitstatus_exec &>/dev/null    || function _gitstatus_exec()    { exec    "$@"; }
     type -t _gitstatus_builtin &>/dev/null || function _gitstatus_builtin() { builtin "$@"; }
 


### PR DESCRIPTION
I initially received a related issue at https://github.com/akinomyoga/ble.sh/issues/93. This finally turned out to be related to the following settings in `gitstatus.plugin.sh`:

```bash
    alias exec=_gitstatus_exec_wrapper
    alias builtin=_gitstatus_builtin_wrapper
```

These cause every kind of problem. In particular, the builtin `builtin` is intended to protect the scripts from such modified builtin behavior so isn't expected to be replaced by an alias or a function.

- The persistent redirections, such as `exec 3> file`, don't work anymore because it is replaced by `_gitstatus_exec_wrapper 3> file` and the real `exec` is executed inside `_gitstatus_exec_wrapper`. In this case, the redirection `3> file` will not be treated by the special rule for `exec`, so the effect of the redirection is not persistent after the execution of the command.
- `builtin unset -v var` becomes to remove the local variables instead of changing the variable states to `unset`. In Bash, the behavior of `unset` changes depending on the way how `unset` could find the variable: When `unset` finds the variable in local scope, `unset` sets the variable state to `unset`. When `unset` finds the variable by dynamic scoping, `unset` removes the variable placeholder in the function call chain. As a result, the upper level of the variable placeholder becomes visible. If one replaces `builtin` with a shell function, the variables become always found through the dynamic scoping, so the behavior becomes different.
- The meaning of `builtin eval 'echo $1'` will change. The positional parameters `$1`, `$2`, ... in eval arguments are supposed to reference the values in the context of `builtin eval 'echo $1'`. However, if one replaces `builtin` with a function, these parameters start to reference the arguments specified to `_gitstatus_builtin_wrapper`.
  - Single argument `source` i.e., `builtin source file.sh` is also affected. Inside the sourced file `file.sh`, the parameters `$1`, etc. of the caller context should be able to be referenced. If `builtin` is replaced, the parameters `$1`, etc. are changed to the arguments specified to the wrapper function.
  - the same problems occur with many other builtins: `builtin printf -v 'a[$1]'`, `builtin unset -v 'a[$1]'`, `builtin test -v 'a[$1]'`, `v='x=a[$1]'; builtin let v`, `declare 'a=([$1]=1)'`, `read 'a[$1]'`, etc.

As real problems:

- My shell setting `ble.sh` was completely broken by the replaced `builtin` https://github.com/akinomyoga/ble.sh/issues/93 (Now I have added a workaround to protect `ble.sh` from aliased `builtin`, so now it doesn't break)
- In the same thread, I received a report on a similar problem by `gitstatus.plugin.sh`: [`sudo docker exec`](https://github.com/akinomyoga/ble.sh/issues/93#issuecomment-803454860) fails.

To borrow [@romkatv's words](https://github.com/romkatv/gitstatus/issues/154#issuecomment-653722809), "*It's generally not a good idea to redefine builtins.*" In particular, redefining the `builtin` builtin is the most one that we want to avoid. Isn't there any other way to detect `exec other_program`?

- For example, we may constantly test if the parent shell is still alive or not from the daemon process by using `kill -0 $$`. In this way, one cannot detect if the parent process is replaced by another program using `exec`, but better than doing nothing.
- For example, if we have `procfs`, we could check `/proc/$$/cmdline` to see if the process is replaced or not.

Anyway, I believe we should by default turn off `GITSTATUS_STOP_ON_EXEC`.
