### PR TITLE
Trim '\w' part of bash prompt.

### DIFF
--- a/gitstatus.prompt.sh
+++ b/gitstatus.prompt.sh
@@ -86,6 +86,7 @@ gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
 
 # On every prompt, fetch git status and set GITSTATUS_PROMPT.
 PROMPT_COMMAND=gitstatus_prompt_update
+PROMPT_DIRTRIM=3
 
 # Enable promptvars so that ${GITSTATUS_PROMPT} in PS1 is expanded.
 shopt -s promptvars


### PR DESCRIPTION
See https://wiki.ubuntuusers.de/Bash/Prompt for details.

Much like in `gitstatus.prompt.zsh`, the “working directory” part of the **Bash** prompt in `gitstatus.prompt.sh`  can easily be trimmed to a more sensible size in case of deeply nested paths.