### PR TITLE
Don't overwrite PROMPT_COMMAND variable

### DIFF
--- a/gitstatus.prompt.sh
+++ b/gitstatus.prompt.sh
@@ -85,7 +85,7 @@ function gitstatus_prompt_update() {
 gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
 
 # On every prompt, fetch git status and set GITSTATUS_PROMPT.
-PROMPT_COMMAND=gitstatus_prompt_update
+PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND$';'} gitstatus_prompt_update"
 PROMPT_DIRTRIM=3
 
 # Enable promptvars so that ${GITSTATUS_PROMPT} in PS1 is expanded.


### PR DESCRIPTION
Currently if PROMPT_COMMAND has been set before sourcing the bash prompt script it will be overwritten. This should fix that by keeping whatever is already set and append the `gitstatus_prompt_update`