### PR TITLE
don't force checking for dirty submodules

### DIFF
--- a/src/repo.cc
+++ b/src/repo.cc
@@ -277,7 +277,6 @@ void Repo::StartDirtyScan(const std::vector<const char*>& paths) {
   } else {
     opt.flags |= GIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS;
   }
-  opt.ignore_submodules = GIT_SUBMODULE_IGNORE_DIRTY;
   opt.notify_cb = +[](const git_diff* diff, const git_diff_delta* delta,
                       const char* matched_pathspec, void* payload) -> int {
     if (delta->status == GIT_DELTA_CONFLICTED) return GIT_DIFF_DELTA_DO_NOT_INSERT;


### PR DESCRIPTION
`opts.ignore_submodules = GIT_SUBMODULE_IGNORE_DIRTY` is equivalent to setting the `git status` flag `--ignore-submodules=dirty`, which takes precedence per-submodule `ignore` settings in .gitmodules. This means that `gitstatus` returns a different result than a default `git status` call with no flags if there are any dirty submodules that are marked `ignore = all` in .gitsubmodules.

This is confusing because `git status` and `gitstatusd` will be out of sync and there's no obvious reason why.

This should only result in a behavior change for  projects with submodules that set the .gitmodules config value
`submodule.<name>.ignore` to something besides `none` or `dirty`, but in all cases it will ensure `git status` and `gitstatusd` are in agreement.

Fixes #356.