### PR TITLE
Improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ LDLIBS += -lgit2 # -lprofiler -lunwind
 SRCS := $(shell find src -name "*.cc")
 OBJS := $(patsubst src/%.cc, $(OBJDIR)/%.o, $(SRCS))
 
+# Check if g++ is installed
+ifeq (, $(shell which $(CXX)))
+  $(error "No $(CXX) found in $(PATH), please install g++ and try again")
+endif
+
 all: $(APPNAME)
 
 $(APPNAME): usrbin/$(APPNAME)
@@ -44,3 +49,17 @@ pkg: zwc
 	GITSTATUS_DAEMON= GITSTATUS_CACHE_DIR=$(shell pwd)/usrbin ./install -f
 
 -include $(OBJS:.o=.dep)
+
+.PHONY: help
+
+help:
+	@echo "Usage: make [TARGET]"
+	@echo "Available targets:"
+	@echo "  all         Build the $(APPNAME) application (default target)"
+	@echo "  clean       Remove generated files and directories"
+	@echo "  zwc         Compile Zsh files"
+	@echo "  minify      Remove unnecessary files and folders"
+	@echo "  pkg         Create a package"
+	@echo ""
+	@echo "For more information, see the project's documentation or README file."
+


### PR DESCRIPTION
Two improvements on `Makefile`:

* It will first check if required dependency g++ is installed. If not, inform the user
* Added a `make help` command to list possible options

Note that default behavior of command `make` has not changed, and will still default to `make all`, instead of the more common `make help`. This is done on purpose not to change the behavior of the command.