### PR TITLE
Append to PROMPT_COMMAND

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ function my_set_prompt() {
 }
 
 gitstatus_stop && gitstatus_start
-PROMPT_COMMAND=my_set_prompt
+PROMPT_COMMAND+=(my_set_prompt)
 ```
 
 This snippet is sourcing `gitstatus.plugin.sh` rather than `gitstatus.prompt.sh`. The former

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ function my_set_prompt() {
 }
 
 gitstatus_stop && gitstatus_start
-PROMPT_COMMAND+=(my_set_prompt)
+PROMPT_COMMAND=my_set_prompt
 ```
 
 This snippet is sourcing `gitstatus.plugin.sh` rather than `gitstatus.prompt.sh`. The former

--- a/gitstatus.prompt.sh
+++ b/gitstatus.prompt.sh
@@ -85,7 +85,7 @@ function gitstatus_prompt_update() {
 gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
 
 # On every prompt, fetch git status and set GITSTATUS_PROMPT.
-PROMPT_COMMAND=gitstatus_prompt_update
+PROMPT_COMMAND+=(gitstatus_prompt_update)
 PROMPT_DIRTRIM=3
 
 # Enable promptvars so that ${GITSTATUS_PROMPT} in PS1 is expanded.

--- a/gitstatus.prompt.sh
+++ b/gitstatus.prompt.sh
@@ -85,7 +85,7 @@ function gitstatus_prompt_update() {
 gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
 
 # On every prompt, fetch git status and set GITSTATUS_PROMPT.
-PROMPT_COMMAND+=(gitstatus_prompt_update)
+[[ $PROMPT_COMMAND =~ gitstatus_prompt_update ]] || PROMPT_COMMAND="gitstatus_prompt_update;${PROMPT_COMMAND:-:}"
 PROMPT_DIRTRIM=3
 
 # Enable promptvars so that ${GITSTATUS_PROMPT} in PS1 is expanded.


### PR DESCRIPTION
### Issue

The problem is when using other BASH prompting packages, gitstatus clobbers the PROMPT_COMMAND envar.

This results in an ordering issue; gitstatus has to be the first package to be sourced before other prompt packages, otherwise gitstatus will clobber the existing PROMPT_COMMAND.

This patch simply appends gitstatus to the PROMPT_COMMAND array so that source order becomes irrelevant and gitstatus plays nicely with other prompt packages.

From Bash manual:
```
 PROMPT_COMMAND
    If this variable is set, and is an array, the value of each set
    element is executed as a command prior to issuing each primary
    prompt.  If this is set but not an array variable, its value is
    used as a command to execute instead.
```

### Testing current behavior

```bash
# gitstatus last - broken
~$ PS1='\w\$ ' bash --norc
~$ echo ${PROMPT_COMMAND[@]}

~$ source ${HOMEBREW_PREFIX}/opt/kube-ps1/share/kube-ps1.sh
~$ echo ${PROMPT_COMMAND[@]}
_kube_ps1_prompt_update;:
~$ source ${HOMEBREW_PREFIX}/opt/gitstatus/gitstatus.prompt.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
gitstatus_prompt_update
samiam@mac ~
$ exit
exit

# gitstatus first - ok
~$ PS1='\w\$ ' bash --norc
~$ echo ${PROMPT_COMMAND[@]}

~$ source ${HOMEBREW_PREFIX}/opt/gitstatus/gitstatus.prompt.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
gitstatus_prompt_update
samiam@mac ~
$ source ${HOMEBREW_PREFIX}/opt/kube-ps1/share/kube-ps1.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
_kube_ps1_prompt_update;gitstatus_prompt_update
samiam@mac ~
$ exit
exit
```

### Testing patched behavior
```bash
# gitstatus last - ok
~$ PS1='\w\$ ' bash --norc
~$ echo ${PROMPT_COMMAND[@]}

~$ source ${HOMEBREW_PREFIX}/opt/kube-ps1/share/kube-ps1.sh
~$ echo ${PROMPT_COMMAND[@]}
_kube_ps1_prompt_update;:
~$ source ${HOMEBREW_PREFIX}/opt/gitstatus/gitstatus.prompt.p1.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
_kube_ps1_prompt_update;: gitstatus_prompt_update
samiam@mac ~
$ exit
exit

# gitstatus first - ok
~$ PS1='\w\$ ' bash --norc
~$ echo ${PROMPT_COMMAND[@]}

~$ source ${HOMEBREW_PREFIX}/opt/gitstatus/gitstatus.prompt.p1.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
gitstatus_prompt_update
samiam@mac ~
$ source ${HOMEBREW_PREFIX}/opt/kube-ps1/share/kube-ps1.sh
samiam@mac ~
$ echo ${PROMPT_COMMAND[@]}
_kube_ps1_prompt_update;gitstatus_prompt_update
samiam@mac ~
$ exit
exit
```