### PR TITLE
Specify cmake generator in build file

### DIFF
--- a/build
+++ b/build
@@ -393,6 +393,7 @@ CFLAGS="$libgit2_cflags" command cmake \
   -DUSE_GSSAPI=OFF                     \
   -DUSE_NTLMCLIENT=OFF                 \
   -DBUILD_SHARED_LIBS=OFF              \
+  -G "Unix Makefiles"                  \
   $libgit2_cmake_flags                 \
   ..
 command make -j "$cpus" VERBOSE=1


### PR DESCRIPTION
Building this tool fails if your system environment [specifies a custom CMake generator](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR.html) as later steps depend on the presence of a Makefile. This change overrides that setting, asking CMake to generate a Makefile regardless.
Currently, building the [AUR](https://aur.archlinux.org) package for [zsh-theme-powerlevel10k](https://aur.archlinux.org/packages/zsh-theme-powerlevel10k) fails when using a custom default generator, which should be fixed by implementing this change.