### PR TITLE
Compiling on mips64

### DIFF
--- a/build
+++ b/build
@@ -551,6 +551,7 @@ if [ -z "$gitstatus_cpu" ]; then
     arm64|aarch64)  gitstatus_cpu=armv8-a;;
     ppc64|ppc64le)  gitstatus_cpu=powerpc64le;;
     riscv64)        gitstatus_cpu=rv64imafdc;;
+    mips64)         gitstatus_cpu=mips64;;
     loongarch64)    gitstatus_cpu=loongarch64;;
     x86_64|amd64)   gitstatus_cpu=x86-64;;
     x86)            gitstatus_cpu=i586;;


### PR DESCRIPTION
Fix the error on mips64 cpu:

> [error] unable to infer target CPU architecture
> Please specify explicitly with `-c CPU`.

This commit was tested on my own mips64el debian sid PC. The compiling goes well.